### PR TITLE
Added GET API for balance sheet item file download, refactored file metadata schema

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -4,4 +4,5 @@ Scripts and other artifacts useful in bundling and building stuff.
 
 ## Useful scripts
 
-- [Validate, build and bundle OpenAPI specs script](dev.generate.src.sh)
+- [Validate, build and bundle OpenAPI specs script](dev.generate.src.sh) 
+  - usage ```./build/dev.generate.src.sh```

--- a/specs/resources/balance-sheet-item-file.yml
+++ b/specs/resources/balance-sheet-item-file.yml
@@ -1,3 +1,36 @@
+get:
+  operationId: getBalanceSheetItemFile
+  summary: Download balance sheet item file.
+  description: > 
+    Download balance sheet item file.
+  tags:
+    - "balance-sheets"
+    - "balance-sheets-items"
+    - "files"
+    - "download"
+  parameters:
+    # File ID
+    - $ref: "../alex-api.yml#/components/parameters/CommonFileIdParameter"
+    # Balance sheet item ID
+    - $ref: "../alex-api.yml#/components/parameters/CommonIdParameter"
+    # Common general parameters
+    - $ref: '../alex-api.yml#/components/parameters/CommonTenantParameter'
+    - $ref: '../alex-api.yml#/components/parameters/CommonCultureParameter'
+  responses:
+    '200':
+      description: Download balance sheet item file.
+      content:
+        application/octetstream:
+          schema:
+            type: "string"
+            format: "binary"
+    # Common responses
+    '400':
+      $ref: '../alex-api.yml#/components/responses/InvalidOperation'
+    '401':
+      $ref: '../alex-api.yml#/components/responses/UnauthorizedError'
+    '403':
+      $ref: '../alex-api.yml#/components/responses/ForbiddenError'
 delete:
   operationId: deleteBalanceSheetItemFile
   summary: Delete balance sheet item file.

--- a/specs/resources/balance-sheet-item-files.yml
+++ b/specs/resources/balance-sheet-item-files.yml
@@ -22,7 +22,7 @@ get:
           schema:
             type: array
             items:
-              $ref: '../alex-api.yml#/components/schemas/FileAttachmentDTO'
+              $ref: '../alex-api.yml#/components/schemas/FileMetadataDTO'
     # Common responses
     '400':
       $ref: '../alex-api.yml#/components/responses/InvalidOperation'

--- a/specs/schemas/_index.yml
+++ b/specs/schemas/_index.yml
@@ -10,8 +10,8 @@ Culture:
   $ref: "./culture.yml"
 CsoDTO:
   $ref: "./cso.yml"
-FileAttachmentDTO:
-  $ref: "./common-file-attachment.yml"
+FileMetadataDTO:
+  $ref: "./common-file-metadata.yml"
 SponsorDTO:
   $ref: "./sponsor.yml"
 SponsorUpdateDTO:

--- a/specs/schemas/balance-sheet-item.yml
+++ b/specs/schemas/balance-sheet-item.yml
@@ -50,6 +50,6 @@ properties:
   fileIds:
     type: array
     items:
-      $ref: '../alex-api.yml#/components/schemas/FileAttachmentDTO'
+      $ref: '../alex-api.yml#/components/schemas/FileMetadataDTO'
     description: IDs of files that can be used with file API.
   

--- a/specs/schemas/common-file-metadata.yml
+++ b/specs/schemas/common-file-metadata.yml
@@ -1,5 +1,5 @@
 type: object
-title: FileAttachmentDTO
+title: FileMetadataDTO
 description: Common file attachment DTO.
 properties:
   id:


### PR DESCRIPTION
### What does it fix?

Changes related to #51. Added download balance sheet file API. Refactored DTO name for file metadata.

### How has it been tested?

Using ```./build/dev.generate.src.sh``` script.